### PR TITLE
Fix small warning produced by GCC 5.3.

### DIFF
--- a/gcc/brig/brigfrontend/brig-basic-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-basic-inst-handler.cc
@@ -88,7 +88,7 @@ brig_basic_inst_handler::must_be_scalarized (const BrigInstBase *brig_inst,
 {
   if (!VECTOR_TYPE_P (instr_type))
     return false;
-  if (!brig_inst->opcode == BRIG_OPCODE_MULHI)
+  if (brig_inst->opcode != BRIG_OPCODE_MULHI)
     return false;
 
   // There is limited support for vector highpart mul nodes,


### PR DESCRIPTION
brig-basic-inst-handler.cc:91:26: warning: logical not is only applied
to the left hand side of comparison [-Wlogical-not-parentheses]
   if (!brig_inst->opcode == BRIG_OPCODE_MULHI)