### PR TITLE
Change copyright format to follow GNU style.

### DIFF
--- a/gcc/brig/brig-c.h
+++ b/gcc/brig/brig-c.h
@@ -1,5 +1,7 @@
 /* brig-c.h -- Header file for brig input's gcc C interface.
-   Copyright (C) 2009-2014 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
+
 #ifndef BRIG_BRIG_C_H
 #define BRIG_BRIG_C_H
 

--- a/gcc/brig/brig-lang.c
+++ b/gcc/brig/brig-lang.c
@@ -1,5 +1,7 @@
 /* brig-lang.c -- brig (HSAIL) input gcc interface.
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
+
 #include "config.h"
 #include "system.h"
 #include "ansidecl.h"

--- a/gcc/brig/brigfrontend/brig-arg-block-handler.cc
+++ b/gcc/brig/brigfrontend/brig-arg-block-handler.cc
@@ -1,5 +1,7 @@
 /* brig-arg-block-handler.cc -- brig arg block start/end directive handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,6 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include "brig-code-entry-handler.h"
 #include "tree-iterator.h"

--- a/gcc/brig/brigfrontend/brig-atomic-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-atomic-inst-handler.cc
@@ -1,6 +1,8 @@
 /* brig-atomic-inst-handler.cc -- brig atomic instruction handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
 
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
    This file is part of GCC.
 
    GCC is free software; you can redistribute it and/or modify it under
@@ -16,9 +18,6 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include <sstream>
 

--- a/gcc/brig/brigfrontend/brig-basic-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-basic-inst-handler.cc
@@ -1,5 +1,7 @@
 /* brig-basic-inst-handler.cc -- brig basic instruction handling
-   Copyright (C) 2015-2016 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,6 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015-2016
- */
 
 #include <sstream>
 

--- a/gcc/brig/brigfrontend/brig-branch-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-branch-inst-handler.cc
@@ -1,5 +1,7 @@
 /* brig-branch-inst-handler.cc -- brig branch instruction handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,6 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include "brig-code-entry-handler.h"
 

--- a/gcc/brig/brigfrontend/brig-cmp-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-cmp-inst-handler.cc
@@ -1,5 +1,7 @@
 /* brig-cmp-inst-handler.cc -- brig cmp instruction handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,6 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include "brig-code-entry-handler.h"
 #include "diagnostic.h"

--- a/gcc/brig/brigfrontend/brig-code-entry-handler.cc
+++ b/gcc/brig/brigfrontend/brig-code-entry-handler.cc
@@ -1,5 +1,7 @@
 /* brig-code-entry-handler.cc -- a gccbrig base class
-   Copyright (C) 2015-2016 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,6 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech.
- */
 
 #include "brig-code-entry-handler.h"
 

--- a/gcc/brig/brigfrontend/brig-code-entry-handler.h
+++ b/gcc/brig/brigfrontend/brig-code-entry-handler.h
@@ -1,5 +1,7 @@
 /* brig-code-entry-handler.h -- a gccbrig base class
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,6 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #ifndef GCC_BRIG_CODE_ENTRY_HANDLER_H
 #define GCC_BRIG_CODE_ENTRY_HANDLER_H

--- a/gcc/brig/brigfrontend/brig-comment-handler.cc
+++ b/gcc/brig/brigfrontend/brig-comment-handler.cc
@@ -1,5 +1,7 @@
 /* brig-comment-handler.cc -- brig comment directive handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,6 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include "brig-code-entry-handler.h"
 

--- a/gcc/brig/brigfrontend/brig-control-handler.cc
+++ b/gcc/brig/brigfrontend/brig-control-handler.cc
@@ -1,5 +1,7 @@
 /* brig-control-handler.cc -- brig control directive handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,6 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include "brig-code-entry-handler.h"
 

--- a/gcc/brig/brigfrontend/brig-copy-move-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-copy-move-inst-handler.cc
@@ -1,5 +1,7 @@
 /* brig-copy-move-inst-handler.cc -- brig copy/move instruction handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,6 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include "brig-code-entry-handler.h"
 #include "tree-pretty-print.h"

--- a/gcc/brig/brigfrontend/brig-cvt-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-cvt-inst-handler.cc
@@ -1,5 +1,7 @@
 /* brig-cvt-inst-handler.cc -- brig cvt (convert) instruction handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,6 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include <sstream>
 

--- a/gcc/brig/brigfrontend/brig-fbarrier-handler.cc
+++ b/gcc/brig/brigfrontend/brig-fbarrier-handler.cc
@@ -1,5 +1,7 @@
 /* brig-fbarrier-handler.cc -- brig fbarrier directive handling
    Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,6 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2016
- */
 
 #include "brig-code-entry-handler.h"
 

--- a/gcc/brig/brigfrontend/brig-function-handler.cc
+++ b/gcc/brig/brigfrontend/brig-function-handler.cc
@@ -1,5 +1,7 @@
 /* brig-code-entry-handler.cc -- brig function directive handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,7 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
+
 #include <sstream>
 #include <iomanip>
 

--- a/gcc/brig/brigfrontend/brig-function.cc
+++ b/gcc/brig/brigfrontend/brig-function.cc
@@ -1,5 +1,7 @@
 /* brig-function.cc -- declaration of brig_function class.
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,6 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include <sstream>
 #include <iomanip>

--- a/gcc/brig/brigfrontend/brig-function.h
+++ b/gcc/brig/brigfrontend/brig-function.h
@@ -1,5 +1,7 @@
 /* brig-function.h -- declaration of brig_function class.
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,7 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
+
 #ifndef BRIG_FUNCTION_H
 #define BRIG_FUNCTION_H
 

--- a/gcc/brig/brigfrontend/brig-inst-mod-handler.cc
+++ b/gcc/brig/brigfrontend/brig-inst-mod-handler.cc
@@ -1,5 +1,7 @@
 /* brig-inst-mod-handler.cc -- brig rounding moded instruction handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
+
 #include "brig-code-entry-handler.h"
 
 #include "gimple-expr.h"

--- a/gcc/brig/brigfrontend/brig-label-handler.cc
+++ b/gcc/brig/brigfrontend/brig-label-handler.cc
@@ -1,5 +1,7 @@
 /* brig-label-handler.cc -- brig label directive handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,6 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include "brig-code-entry-handler.h"
 

--- a/gcc/brig/brigfrontend/brig-lane-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-lane-inst-handler.cc
@@ -1,5 +1,7 @@
 /* brig-lane-inst-handler.cc -- brig lane instruction handling
    Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,6 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2016
- */
 
 #include "brig-code-entry-handler.h"
 #include "errors.h"

--- a/gcc/brig/brigfrontend/brig-machine.c
+++ b/gcc/brig/brigfrontend/brig-machine.c
@@ -1,5 +1,7 @@
 /* brig-machine.c -- gccbrig machine queries
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
+
 #include "brig-machine.h"
 
 unsigned

--- a/gcc/brig/brigfrontend/brig-machine.h
+++ b/gcc/brig/brigfrontend/brig-machine.h
@@ -1,5 +1,5 @@
 /* brig-machine.h -- gccbrig machine queries
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/gcc/brig/brigfrontend/brig-mem-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-mem-inst-handler.cc
@@ -1,5 +1,7 @@
 /* brig-mem-inst-handler.cc -- brig memory inst handler
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,6 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include "brig-code-entry-handler.h"
 

--- a/gcc/brig/brigfrontend/brig-module-handler.cc
+++ b/gcc/brig/brigfrontend/brig-module-handler.cc
@@ -1,5 +1,7 @@
 /* brig-module-handler.cc -- brig module directive handling
    Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,7 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2016
- */
+
 #include "brig-code-entry-handler.h"
 
 size_t

--- a/gcc/brig/brigfrontend/brig-queue-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-queue-inst-handler.cc
@@ -1,6 +1,8 @@
 /* brig-queue-inst-handler.cc -- brig user mode queue related instruction
 handling
-   Copyright (C) 2015-2016 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -17,9 +19,6 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015-2016
- */
 
 #include <sstream>
 

--- a/gcc/brig/brigfrontend/brig-seg-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-seg-inst-handler.cc
@@ -1,5 +1,7 @@
 /* brig-seg-inst-handler.cc -- brig segment related instruction handling
-   Copyright (C) 2015-2016 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,6 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015-2016
- */
 
 #include <sstream>
 

--- a/gcc/brig/brigfrontend/brig-signal-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-signal-inst-handler.cc
@@ -1,5 +1,7 @@
 /* brig-signal-inst-handler.cc -- brig signal instruction handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,6 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include <sstream>
 

--- a/gcc/brig/brigfrontend/brig-util.cc
+++ b/gcc/brig/brigfrontend/brig-util.cc
@@ -1,5 +1,7 @@
 /* brig-util.cc -- gccbrig utility functions
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,6 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 // Some code reused from Martin Jambor's gcc-hsa tree.
 

--- a/gcc/brig/brigfrontend/brig-util.h
+++ b/gcc/brig/brigfrontend/brig-util.h
@@ -1,5 +1,7 @@
 /* brig-util.h -- gccbrig utility functions
-   Copyright (C) 2015-2016 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015-2016
- */
+
 #ifndef GCC_BRIG_UTIL_H
 #define GCC_BRIG_UTIL_H
 

--- a/gcc/brig/brigfrontend/brig-variable-handler.cc
+++ b/gcc/brig/brigfrontend/brig-variable-handler.cc
@@ -1,5 +1,7 @@
 /* brig-variable-handler.cc -- brig variable directive handling
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,6 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
 
 #include "brig-code-entry-handler.h"
 

--- a/gcc/brig/brigfrontend/brig_to_generic.cc
+++ b/gcc/brig/brigfrontend/brig_to_generic.cc
@@ -1,5 +1,7 @@
 /* brig2tree.cc -- brig to gcc generic/gimple tree conversion
-   Copyright (C) 2015-2016 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,7 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015-2016
- */
+
 #include <cassert>
 #include <iostream>
 #include <iomanip>

--- a/gcc/brig/brigfrontend/brig_to_generic.h
+++ b/gcc/brig/brigfrontend/brig_to_generic.h
@@ -1,5 +1,7 @@
 /* brig_to_generic.h -- brig to gcc generic conversion
-   Copyright (C) 2015-2016 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
    This file is part of GCC.
 
@@ -16,9 +18,7 @@
    You should have received a copy of the GNU General Public License
    along with GCC; see the file COPYING3.  If not see
    <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
+
 #ifndef BRIG_TO_GENERIC_H
 #define BRIG_TO_GENERIC_H
 
@@ -43,7 +43,6 @@
  * of the smaller pieces of BRIG data is delegated to various handler
  * classes declared in brig-code-entry-handlers.h.
  *
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech.
  */
 
 struct reg_decl_index_entry;

--- a/gcc/brig/brigfrontend/phsa.h
+++ b/gcc/brig/brigfrontend/phsa.h
@@ -1,5 +1,7 @@
 /* phsa.h -- phsa interfacing
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,6 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech.
- */
 
 #ifndef PHSA_H
 #define PHSA_H

--- a/gcc/brig/brigspec.c
+++ b/gcc/brig/brigspec.c
@@ -1,5 +1,7 @@
 /* brigspec.c -- Specific flags and argument handling of the gcc BRIG front end.
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
+
 #include "config.h"
 #include "system.h"
 #include "coretypes.h"

--- a/gcc/brig/lang-specs.h
+++ b/gcc/brig/lang-specs.h
@@ -1,5 +1,7 @@
 /* lang-specs.h -- gcc driver specs for BRIG (HSAIL) frontend.
-   Copyright (C) 2015 Free Software Foundation, Inc.
+   Copyright (C) 2016 Free Software Foundation, Inc.
+   Contributed by Pekka Jaaskelainen <pekka.jaaskelainen@parmance.com>
+   for General Processor Tech.
 
 This file is part of GCC.
 
@@ -16,9 +18,7 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
-/**
- * @author pekka.jaaskelainen@parmance.com for General Processor Tech. 2015
- */
+
 /* This is the contribution to the `default_compilers' array in gcc.c
    for the BRIG (HSAIL) input.  */
 


### PR DESCRIPTION
Hello.

Following pull request changes copyright format and rewrites all dates to be '2016'. As the patch is expected to merged to trunk in 2016, I think it's the correct way.

Thanks,
Martin