### PR TITLE
Fix 'function_name()' parenthesis coding style issue.

### DIFF
--- a/gcc/brig/brig-c.h
+++ b/gcc/brig/brig-c.h
@@ -63,6 +63,6 @@ extern void brig_write_export_data (const char *, unsigned int);
 
 extern const char *brig_read_export_data (int, off_t, char **, size_t *, int *);
 
-// extern GTY(()) tree brig_non_zero_struct;
+// extern GTY (()) tree brig_non_zero_struct;
 
-#endif /* !defined(BRIG_BRIG_C_H) */
+#endif /* !defined (BRIG_BRIG_C_H) */

--- a/gcc/brig/brig-lang.c
+++ b/gcc/brig/brig-lang.c
@@ -300,10 +300,10 @@ brig_langhook_type_for_mode (enum machine_mode mode, int unsignedp)
     }
   else
     {
-      /* E.g., build_common_builtin_nodes() asks for modes/builtins
+      /* E.g., build_common_builtin_nodes () asks for modes/builtins
 	       we do not generate or need. Just ignore them silently for now.
       internal_error ("unsupported mode %s unsignedp %d\n",
-								      GET_MODE_NAME(mode),
+								      GET_MODE_NAME (mode),
       unsignedp);
       */
       return void_type_node;

--- a/gcc/brig/brigfrontend/brig-arg-block-handler.cc
+++ b/gcc/brig/brigfrontend/brig-arg-block-handler.cc
@@ -29,7 +29,7 @@
 #include "print-tree.h"
 
 size_t
-brig_directive_arg_block_handler::operator() (const BrigBase *base)
+brig_directive_arg_block_handler::operator () (const BrigBase *base)
 {
   if (base->kind == BRIG_KIND_DIRECTIVE_ARG_BLOCK_START)
     {

--- a/gcc/brig/brigfrontend/brig-atomic-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-atomic-inst-handler.cc
@@ -368,7 +368,7 @@ brig_atomic_inst_handler::generate_tree (const BrigInstBase &inst,
 }
 
 size_t
-brig_atomic_inst_handler::operator() (const BrigBase *base)
+brig_atomic_inst_handler::operator () (const BrigBase *base)
 {
   const BrigInstAtomic *inst = (const BrigInstAtomic *) base;
   BrigAtomicOperation8_t atomic_opcode;

--- a/gcc/brig/brigfrontend/brig-basic-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-basic-inst-handler.cc
@@ -94,7 +94,7 @@ brig_basic_inst_handler::must_be_scalarized (const BrigInstBase *brig_inst,
   // There is limited support for vector highpart mul nodes,
   // and it probably depends on the target which ones are
   // supported. TO DO: figure out a more robust way to ask this
-  // from the target. can_mult_highpart_p() from optabs.c seems
+  // from the target. can_mult_highpart_p () from optabs.c seems
   // not to be reliable enough.
 
   size_t elements = TYPE_VECTOR_SUBPARTS (instr_type);
@@ -452,7 +452,7 @@ brig_basic_inst_handler::build_instr_expr (BrigOpcode16_t brig_opcode,
 }
 
 size_t
-brig_basic_inst_handler::operator() (const BrigBase *base)
+brig_basic_inst_handler::operator () (const BrigBase *base)
 {
   const BrigInstBase *brig_inst = (const BrigInstBase *) base;
 

--- a/gcc/brig/brigfrontend/brig-branch-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-branch-inst-handler.cc
@@ -29,7 +29,7 @@
 #include "vec.h"
 
 size_t
-brig_branch_inst_handler::operator() (const BrigBase *base)
+brig_branch_inst_handler::operator () (const BrigBase *base)
 {
   const BrigInstBase *brig_inst
     = (const BrigInstBase *) &((const BrigInstBasic *) base)->base;

--- a/gcc/brig/brigfrontend/brig-cmp-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-cmp-inst-handler.cc
@@ -28,7 +28,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "convert.h"
 
 size_t
-brig_cmp_inst_handler::operator() (const BrigBase *base)
+brig_cmp_inst_handler::operator () (const BrigBase *base)
 {
   const BrigInstBase *inst_base = (const BrigInstBase *) base;
   const BrigInstCmp *inst = (const BrigInstCmp *) base;

--- a/gcc/brig/brigfrontend/brig-code-entry-handler.cc
+++ b/gcc/brig/brigfrontend/brig-code-entry-handler.cc
@@ -421,7 +421,7 @@ brig_code_entry_handler::brig_code_entry_handler (brig_to_generic &parent)
 		      u8x4_type, u8x4_type, u16x2_type);
 
   // TODO: clock has code motion constraints. Should add function attributes
-  // to prevent reordering with mem instructions or other clock() calls.
+  // to prevent reordering with mem instructions or other clock () calls.
   add_custom_builtin (BRIG_OPCODE_CLOCK, BRIG_TYPE_U64, "__phsa_builtin_clock",
 		      0, u64_type);
 
@@ -512,7 +512,7 @@ brig_code_entry_handler::build_tree_operand (const BrigInstBase &brig_inst,
 
 	  // In case a vector is used an input, cast the elements to
 	  // correct size here so we don't need a separate unpack/pack for it.
-	  // fp16-fp32 conversion is done in build_operands().
+	  // fp16-fp32 conversion is done in build_operands ().
 	  if (is_input && TREE_TYPE (element) != operand_type)
 	    {
 	      if (int_size_in_bytes (TREE_TYPE (element))
@@ -2096,7 +2096,7 @@ brig_code_entry_handler::pack (tree_stl_vec &elements)
 }
 
 tree
-tree_element_unary_visitor::operator() (brig_code_entry_handler &handler,
+tree_element_unary_visitor::operator () (brig_code_entry_handler &handler,
 					tree operand)
 {
   if (VECTOR_TYPE_P (TREE_TYPE (operand)))
@@ -2140,7 +2140,7 @@ tree_element_unary_visitor::operator() (brig_code_entry_handler &handler,
 }
 
 tree
-tree_element_binary_visitor::operator() (brig_code_entry_handler &handler,
+tree_element_binary_visitor::operator () (brig_code_entry_handler &handler,
 					 tree operand0, tree operand1)
 {
   if (VECTOR_TYPE_P (TREE_TYPE (operand0)))

--- a/gcc/brig/brigfrontend/brig-code-entry-handler.h
+++ b/gcc/brig/brigfrontend/brig-code-entry-handler.h
@@ -41,7 +41,7 @@ public:
   brig_code_entry_handler (brig_to_generic &parent);
   // Handles the brig_code data at the given pointer and adds it to the
   // currently built tree. Returns the number of consumed bytes;
-  virtual size_t operator() (const BrigBase *base) = 0;
+  virtual size_t operator () (const BrigBase *base) = 0;
 
   void append_statement (tree stmt);
 
@@ -144,7 +144,7 @@ private:
 class tree_element_unary_visitor
 {
 public:
-  tree operator() (brig_code_entry_handler &handler, tree operand);
+  tree operator () (brig_code_entry_handler &handler, tree operand);
 
   // Performs an action to a single element, which can have originally
   // been a vector element or a scalar.
@@ -155,7 +155,7 @@ public:
 class tree_element_binary_visitor
 {
 public:
-  tree operator() (brig_code_entry_handler &handler, tree operand0,
+  tree operator () (brig_code_entry_handler &handler, tree operand0,
 		   tree operand1);
 
   // Performs an action to a pair of elements, which can have originally
@@ -195,7 +195,7 @@ public:
 // A base class for instruction types that support floating point
 // modifiers.
 //
-// operator() delegates to subclasses (template method pattern) in
+// operator () delegates to subclasses (template method pattern) in
 // type specific parts.
 class brig_inst_mod_handler : public brig_code_entry_handler
 {
@@ -209,7 +209,7 @@ public:
   virtual const BrigAluModifier *modifier (const BrigBase *base) const;
   virtual const BrigRound8_t *round (const BrigBase *base) const;
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_directive_function_handler : public brig_code_entry_handler
@@ -219,7 +219,7 @@ public:
     : brig_code_entry_handler (parent)
   {
   }
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_directive_control_handler : public brig_code_entry_handler
@@ -230,7 +230,7 @@ public:
   {
   }
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_directive_variable_handler : public brig_code_entry_handler
@@ -241,7 +241,7 @@ public:
   {
   }
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 
   tree build_variable (const BrigDirectiveVariable *brigVar,
 		       tree_code m_var_decltype = VAR_DECL);
@@ -255,7 +255,7 @@ public:
   {
   }
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_directive_label_handler : public brig_code_entry_handler
@@ -266,7 +266,7 @@ public:
   {
   }
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_directive_comment_handler : public brig_code_entry_handler
@@ -277,7 +277,7 @@ public:
   {
   }
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_directive_arg_block_handler : public brig_code_entry_handler
@@ -288,7 +288,7 @@ public:
   {
   }
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_basic_inst_handler : public brig_code_entry_handler
@@ -296,7 +296,7 @@ class brig_basic_inst_handler : public brig_code_entry_handler
 public:
   brig_basic_inst_handler (brig_to_generic &parent);
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 
 private:
   // Builds a broadcast of the lowest element in the given vector operand.
@@ -339,7 +339,7 @@ public:
   {
   }
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_mem_inst_handler : public brig_code_entry_handler
@@ -350,7 +350,7 @@ public:
   {
   }
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 
 private:
   tree build_mem_access (const BrigInstBase *brig_inst, tree addr, tree data);
@@ -364,7 +364,7 @@ public:
   {
   }
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_atomic_inst_handler : public brig_code_entry_handler
@@ -375,7 +375,7 @@ private:
 public:
   brig_atomic_inst_handler (brig_to_generic &parent);
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 
 protected:
   size_t generate_tree (const BrigInstBase &inst,
@@ -395,7 +395,7 @@ public:
     : brig_atomic_inst_handler (parent)
   {
   }
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_cmp_inst_handler : public brig_code_entry_handler
@@ -406,7 +406,7 @@ public:
   {
   }
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_seg_inst_handler : public brig_code_entry_handler
@@ -414,7 +414,7 @@ class brig_seg_inst_handler : public brig_code_entry_handler
 public:
   brig_seg_inst_handler (brig_to_generic &parent);
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_lane_inst_handler : public brig_code_entry_handler
@@ -422,7 +422,7 @@ class brig_lane_inst_handler : public brig_code_entry_handler
 public:
   brig_lane_inst_handler (brig_to_generic &parent);
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_queue_inst_handler : public brig_code_entry_handler
@@ -430,7 +430,7 @@ class brig_queue_inst_handler : public brig_code_entry_handler
 public:
   brig_queue_inst_handler (brig_to_generic &parent);
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 class brig_directive_module_handler : public brig_code_entry_handler
@@ -441,7 +441,7 @@ public:
   {
   }
 
-  size_t operator() (const BrigBase *base);
+  size_t operator () (const BrigBase *base);
 };
 
 

--- a/gcc/brig/brigfrontend/brig-comment-handler.cc
+++ b/gcc/brig/brigfrontend/brig-comment-handler.cc
@@ -25,7 +25,7 @@ along with GCC; see the file COPYING3.  If not see
 extern int gccbrig_verbose;
 
 size_t
-brig_directive_comment_handler::operator() (const BrigBase *base)
+brig_directive_comment_handler::operator () (const BrigBase *base)
 {
   const BrigDirectiveComment *brig_comment
     = (const BrigDirectiveComment *) base;

--- a/gcc/brig/brigfrontend/brig-control-handler.cc
+++ b/gcc/brig/brigfrontend/brig-control-handler.cc
@@ -23,7 +23,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "brig-code-entry-handler.h"
 
 size_t
-brig_directive_control_handler::operator() (const BrigBase *base)
+brig_directive_control_handler::operator () (const BrigBase *base)
 {
   // Skip (for now) control directives that can be ignored safely.
   return base->byteCount;

--- a/gcc/brig/brigfrontend/brig-copy-move-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-copy-move-inst-handler.cc
@@ -26,7 +26,7 @@
 #include "errors.h"
 
 size_t
-brig_copy_move_inst_handler::operator() (const BrigBase *base)
+brig_copy_move_inst_handler::operator () (const BrigBase *base)
 {
   const BrigInstBase *brig_inst
     = (const BrigInstBase *) &((const BrigInstBasic *) base)->base;

--- a/gcc/brig/brigfrontend/brig-fbarrier-handler.cc
+++ b/gcc/brig/brigfrontend/brig-fbarrier-handler.cc
@@ -29,7 +29,7 @@ along with GCC; see the file COPYING3.  If not see
 #define FBARRIER_STRUCT_SIZE 32
 
 size_t
-brig_directive_fbarrier_handler::operator() (const BrigBase *base)
+brig_directive_fbarrier_handler::operator () (const BrigBase *base)
 {
   // Model fbarriers as group segment variables with fixed size
   // large enough to store whatever data the actual target needs

--- a/gcc/brig/brigfrontend/brig-function-handler.cc
+++ b/gcc/brig/brigfrontend/brig-function-handler.cc
@@ -38,7 +38,7 @@
 extern int gccbrig_verbose;
 
 size_t
-brig_directive_function_handler::operator() (const BrigBase *base)
+brig_directive_function_handler::operator () (const BrigBase *base)
 {
   m_parent.finish_function ();
 

--- a/gcc/brig/brigfrontend/brig-function.cc
+++ b/gcc/brig/brigfrontend/brig-function.cc
@@ -389,13 +389,13 @@ brig_function::build_launcher_and_metadata (size_t group_segment_size,
   /* The launcher function calls the device-side runtime
      that runs the kernel for all work-items. In C:
 
-     void KernelName(void* context, void* group_base_addr) {
+     void KernelName (void* context, void* group_base_addr) {
      __phsa_launch_kernel (_KernelName, context, group_base_addr);
      }
 
      or, in case of a successful conversion to a work-group function:
 
-     void KernelName(void* context, void* group_base_addr) {
+     void KernelName (void* context, void* group_base_addr) {
      __phsa_launch_wg_function (_KernelName, context, group_base_addr);
      }
 
@@ -638,5 +638,5 @@ brig_function::append_return_stmt ()
 bool
 brig_function::has_function_scope_var (const BrigBase* var) const
 {
-  return m_function_scope_vars.find (var) != m_function_scope_vars.end();
+  return m_function_scope_vars.find (var) != m_function_scope_vars.end ();
 }

--- a/gcc/brig/brigfrontend/brig-inst-mod-handler.cc
+++ b/gcc/brig/brigfrontend/brig-inst-mod-handler.cc
@@ -46,16 +46,16 @@ brig_inst_mod_handler::round (const BrigBase *base) const
 }
 
 /**
- * This used to inject fesetround() calls to control the rounding mode of the
+ * This used to inject fesetround () calls to control the rounding mode of the
  * actual executed floating point operation. It turned out that supporting
  * conversions using fesetround calls won't work in gcc due to it not being able
  * to restrict code motions across calls at the moment. This functionality is
  * therefore disabled for now until a better solution is found or if
- * fesetround()
+ * fesetround ()
  * is fixed in gcc.
  */
 size_t
-brig_inst_mod_handler::operator() (const BrigBase *base)
+brig_inst_mod_handler::operator () (const BrigBase *base)
 {
   return generate (base);
 
@@ -119,7 +119,7 @@ brig_inst_mod_handler::operator() (const BrigBase *base)
 
 			// Emit a call to fegetround() to save the current
 			// rounding mode to a temporary variable.
-			// atomic_assign_expand_fenv() target hook
+			// atomic_assign_expand_fenv () target hook
 			// is close to what is wanted here, but it is meant for
 			// disabling exceptions during an atomic operation.
 
@@ -142,7 +142,7 @@ brig_inst_mod_handler::operator() (const BrigBase *base)
 
 	if (new_mode != NULL_TREE)
 		{
-			// TODO: Emit a call to fesetround(int rounding_mode) to
+			// TODO: Emit a call to fesetround (int rounding_mode) to
 			// set the rounding mode to the one stated in the modifier.
 
 			tree restore_call = build_call_expr (m_parent.fesetround_fn, 1, old_mode);

--- a/gcc/brig/brigfrontend/brig-label-handler.cc
+++ b/gcc/brig/brigfrontend/brig-label-handler.cc
@@ -23,7 +23,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "brig-code-entry-handler.h"
 
 size_t
-brig_directive_label_handler::operator() (const BrigBase *base)
+brig_directive_label_handler::operator () (const BrigBase *base)
 {
   const BrigDirectiveLabel *brig_label = (const BrigDirectiveLabel *) base;
 

--- a/gcc/brig/brigfrontend/brig-lane-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-lane-inst-handler.cc
@@ -29,7 +29,7 @@ brig_lane_inst_handler::brig_lane_inst_handler (brig_to_generic &parent)
 }
 
 size_t
-brig_lane_inst_handler::operator() (const BrigBase *base)
+brig_lane_inst_handler::operator () (const BrigBase *base)
 {
   const BrigInstLane &inst = *(const BrigInstLane *) base;
   tree_stl_vec operands = build_operands (inst.base);

--- a/gcc/brig/brigfrontend/brig-mem-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-mem-inst-handler.cc
@@ -72,7 +72,7 @@ brig_mem_inst_handler::build_mem_access (const BrigInstBase *brig_inst,
 }
 
 size_t
-brig_mem_inst_handler::operator() (const BrigBase *base)
+brig_mem_inst_handler::operator () (const BrigBase *base)
 {
   const BrigInstBase *brig_inst
     = (const BrigInstBase *) &((const BrigInstBasic *) base)->base;

--- a/gcc/brig/brigfrontend/brig-module-handler.cc
+++ b/gcc/brig/brigfrontend/brig-module-handler.cc
@@ -22,9 +22,9 @@
 #include "brig-code-entry-handler.h"
 
 size_t
-brig_directive_module_handler::operator() (const BrigBase *base)
+brig_directive_module_handler::operator () (const BrigBase *base)
 {
   const BrigDirectiveModule* mod = (const BrigDirectiveModule*)base;
-  m_parent.m_module_name = m_parent.get_string (mod->name).substr(1);
+  m_parent.m_module_name = m_parent.get_string (mod->name).substr (1);
   return base->byteCount;
 }

--- a/gcc/brig/brigfrontend/brig-queue-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-queue-inst-handler.cc
@@ -35,7 +35,7 @@ brig_queue_inst_handler::brig_queue_inst_handler (brig_to_generic &parent)
 }
 
 size_t
-brig_queue_inst_handler::operator() (const BrigBase *base)
+brig_queue_inst_handler::operator () (const BrigBase *base)
 {
   const BrigInstBase &inst_base = *(const BrigInstBase *) base;
 

--- a/gcc/brig/brigfrontend/brig-seg-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-seg-inst-handler.cc
@@ -34,7 +34,7 @@ brig_seg_inst_handler::brig_seg_inst_handler (brig_to_generic &parent)
 }
 
 size_t
-brig_seg_inst_handler::operator() (const BrigBase *base)
+brig_seg_inst_handler::operator () (const BrigBase *base)
 {
   const BrigInstBase &inst_base = *(const BrigInstBase *) base;
 

--- a/gcc/brig/brigfrontend/brig-signal-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-signal-inst-handler.cc
@@ -33,7 +33,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "gimple-expr.h"
 
 size_t
-brig_signal_inst_handler::operator() (const BrigBase *base)
+brig_signal_inst_handler::operator () (const BrigBase *base)
 {
   const BrigInstSignal *inst = (const BrigInstSignal *) base;
   BrigAtomicOperation8_t atomic_opcode;

--- a/gcc/brig/brigfrontend/brig-variable-handler.cc
+++ b/gcc/brig/brigfrontend/brig-variable-handler.cc
@@ -131,7 +131,7 @@ brig_directive_variable_handler::build_variable (
 }
 
 size_t
-brig_directive_variable_handler::operator() (const BrigBase *base)
+brig_directive_variable_handler::operator () (const BrigBase *base)
 {
   const BrigDirectiveVariable *brigVar = (const BrigDirectiveVariable *) base;
 

--- a/gcc/brig/brigfrontend/brig_to_generic.cc
+++ b/gcc/brig/brigfrontend/brig_to_generic.cc
@@ -91,7 +91,7 @@ public:
   }
 
   size_t
-  operator() (const BrigBase *base)
+  operator () (const BrigBase *base)
   {
     internal_error ("BrigKind 0x%x unimplemented", base->kind);
     return base->byteCount;
@@ -109,7 +109,7 @@ public:
   }
 
   size_t
-  operator() (const BrigBase *base)
+  operator () (const BrigBase *base)
   {
     return base->byteCount;
   }
@@ -349,7 +349,7 @@ brig_to_generic::get_mangled_name
 (const BrigDirectiveExecutable *func) const
 {
   // Strip the leading &.
-  std::string func_name = get_string (func->name).substr(1);
+  std::string func_name = get_string (func->name).substr (1);
   if (func->linkage == BRIG_LINKAGE_MODULE)
     {
       // Mangle the module scope function names with the module name and
@@ -671,6 +671,6 @@ brig_to_generic::write_globals ()
   check_global_declarations (vec, no_globals);
   delete[] vec;
 
-  for (size_t i = 0; i < m_brig_blobs.size(); ++i)
+  for (size_t i = 0; i < m_brig_blobs.size (); ++i)
     delete m_brig_blobs[i];
 }

--- a/gcc/brig/brigfrontend/brig_to_generic.h
+++ b/gcc/brig/brigfrontend/brig_to_generic.h
@@ -185,7 +185,7 @@ template <typename T>
 std::string
 brig_to_generic::get_mangled_name_tmpl (const T *brigVar) const
 {
-  std::string var_name = get_string (brigVar->name).substr(1);
+  std::string var_name = get_string (brigVar->name).substr (1);
   // Mangle the variable name using the function name and the module name. 
   if (m_cf != NULL &&
       m_cf->has_function_scope_var (&brigVar->base))
@@ -203,7 +203,7 @@ public:
   brig_entry_handler (brig_to_generic &parent) : m_parent (parent) {}
   // Handles the brig_code data at the given pointer and adds it to the
   // currently built tree. Returns the number of consumed bytes;
-  virtual size_t operator() (const BrigBase *base) = 0;
+  virtual size_t operator () (const BrigBase *base) = 0;
 
 protected:
   brig_to_generic &m_parent;


### PR DESCRIPTION
Hello.

Following pull request solves issues spotted by check_GNU_style.sh script in situations, where a function name is followed by parenthesis. Same if a function is used in comments, as I've seen other source files, they use the same approach.

Thanks,
Martin