### PR TITLE
Fix GNU coding style

### DIFF
--- a/gcc/brig/Make-lang.in
+++ b/gcc/brig/Make-lang.in
@@ -23,7 +23,8 @@
 # Installation name.
 
 GCCBRIG_INSTALL_NAME := $(shell echo gccbrig|sed '$(program_transform_name)')
-GCCBRIG_TARGET_INSTALL_NAME := $(target_noncanonical)-$(shell echo gccbrig|sed '$(program_transform_name)')
+GCCBRIG_TARGET_INSTALL_NAME := $(target_noncanonical)-$(shell echo gccbrig|sed \
+	'$(program_transform_name)')
 
 # The name for selecting brig in LANGUAGES.
 brig: brig1$(exeext)
@@ -33,7 +34,8 @@ brig: brig1$(exeext)
 CFLAGS-brig/brigspec.o += $(DRIVER_DEFINES)
 
 GCCBRIG_OBJS = $(GCC_OBJS) brig/brigspec.o
-gccbrig$(exeext): $(GCCBRIG_OBJS) $(EXTRA_GCC_OBJS) libcommon-target.a $(LIBDEPS)
+gccbrig$(exeext): $(GCCBRIG_OBJS) $(EXTRA_GCC_OBJS) libcommon-target.a \
+	$(LIBDEPS)
 	+$(LINKER) $(ALL_LINKERFLAGS) $(LDFLAGS) -o $@ \
 	  $(GCCBRIG_OBJS) $(EXTRA_GCC_OBJS) libcommon-target.a \
 	  $(EXTRA_GCC_LIBS) $(LIBS)
@@ -151,14 +153,16 @@ check_brig_parallelize = brig-test.exp=*/test/\[0-57-9a-bd-hj-qs-zA-Z\]* \
 
 brig.install-common: installdirs
 	-rm -f $(DESTDIR)$(bindir)/$(GCCBRIG_INSTALL_NAME)$(exeext)
-	$(INSTALL_PROGRAM) gccbrig$(exeext) $(DESTDIR)$(bindir)/$(GCCBRIG_INSTALL_NAME)$(exeext)
+	$(INSTALL_PROGRAM) gccbrig$(exeext) \
+	$(DESTDIR)$(bindir)/$(GCCBRIG_INSTALL_NAME)$(exeext)
 	-if test -f brig1$(exeext); then \
 	  if test -f gccbrig-cross$(exeext); then \
 	    :; \
 	  else \
 	    rm -f $(DESTDIR)$(bindir)/$(GCCBRIG_TARGET_INSTALL_NAME)$(exeext); \
 	    ( cd $(DESTDIR)$(bindir) && \
-	      $(LN) $(GCCBRIG_INSTALL_NAME)$(exeext) $(GCCBRIG_TARGET_INSTALL_NAME)$(exeext) ); \
+	      $(LN) $(GCCBRIG_INSTALL_NAME)$(exeext) \
+	      $(GCCBRIG_TARGET_INSTALL_NAME)$(exeext) ); \
 	  fi; \
 	fi
 
@@ -180,7 +184,8 @@ brig.install-html: $(build_htmldir)/brig
 	@$(NORMAL_INSTALL)
 	test -z "$(htmldir)" || $(mkinstalldirs) "$(DESTDIR)$(htmldir)"
 	@for p in $(build_htmldir)/brig; do \
-	  if test -f "$$p" || test -d "$$p"; then d=""; else d="$(srcdir)/"; fi; \
+	  if test -f "$$p" || test -d "$$p"; then d=""; else d="$(srcdir)/"; \
+	  fi; \
 	  f=$(html__strip_dir) \
 	  if test -d "$$d$$p"; then \
 	    echo " $(mkinstalldirs) '$(DESTDIR)$(htmldir)/$$f'"; \
@@ -195,7 +200,8 @@ brig.install-html: $(build_htmldir)/brig
 
 brig.install-man: #$(DESTDIR)$(man1dir)/$(GCCBRIG_INSTALL_NAME)$(man1ext)
 
-#$(DESTDIR)$(man1dir)/$(GCCBRIG_INSTALL_NAME)$(man1ext): doc/gccbrig.1 installdirs
+#$(DESTDIR)$(man1dir)/$(GCCBRIG_INSTALL_NAME)$(man1ext): doc/gccbrig.1 \
+#	installdirs
 #	-rm -f $@
 #	-$(INSTALL_DATA) $< $@
 #	-chmod a-x $@

--- a/gcc/brig/brig-lang.c
+++ b/gcc/brig/brig-lang.c
@@ -302,9 +302,8 @@ brig_langhook_type_for_mode (enum machine_mode mode, int unsignedp)
     {
       /* E.g., build_common_builtin_nodes() asks for modes/builtins
 	       we do not generate or need. Just ignore them silently for now.
-      internal_error ("unsupported mode %s unsignedp %d\n",
-								      GET_MODE_NAME(mode),
-      unsignedp);
+      internal_error ("unsupported mode %s unsignedp %d\n", GET_MODE_NAME(mode),
+		      unsignedp);
       */
       return void_type_node;
     }

--- a/gcc/brig/brigfrontend/brig-code-entry-handler.cc
+++ b/gcc/brig/brigfrontend/brig-code-entry-handler.cc
@@ -1510,8 +1510,10 @@ brig_code_entry_handler::expand_builtin (BrigOpcode16_t brig_opcode,
 				 uint32_2);
       id2 = convert (uint64_type_node, id2);
 
-      tree max0 = convert (uint64_type_node, m_parent.m_cf->m_grid_size_vars[0]);
-      tree max1 = convert (uint64_type_node, m_parent.m_cf->m_grid_size_vars[1]);
+      tree max0 = convert (uint64_type_node,
+			   m_parent.m_cf->m_grid_size_vars[0]);
+      tree max1 = convert (uint64_type_node,
+			   m_parent.m_cf->m_grid_size_vars[1]);
 
       tree id2_x_max0_x_max1 = build2 (MULT_EXPR, uint64_type_node, id2, max0);
       id2_x_max0_x_max1
@@ -1552,13 +1554,15 @@ brig_code_entry_handler::expand_builtin (BrigOpcode16_t brig_opcode,
   else if (brig_opcode == BRIG_OPCODE_WORKITEMFLATID)
     {
       tree z_x_wgsx_wgsy
-	= build2 (MULT_EXPR, uint32_type_node, m_parent.m_cf->m_local_id_vars[2],
+	= build2 (MULT_EXPR, uint32_type_node,
+		  m_parent.m_cf->m_local_id_vars[2],
 		  m_parent.m_cf->m_wg_size_vars[0]);
       z_x_wgsx_wgsy = build2 (MULT_EXPR, uint32_type_node, z_x_wgsx_wgsy,
 			      m_parent.m_cf->m_wg_size_vars[1]);
 
       tree y_x_wgsx
-	= build2 (MULT_EXPR, uint32_type_node, m_parent.m_cf->m_local_id_vars[1],
+	= build2 (MULT_EXPR, uint32_type_node,
+		  m_parent.m_cf->m_local_id_vars[1],
 		  m_parent.m_cf->m_wg_size_vars[0]);
 
       tree sum = build2 (PLUS_EXPR, uint32_type_node, y_x_wgsx, z_x_wgsx_wgsy);

--- a/gcc/brig/brigfrontend/brig-inst-mod-handler.cc
+++ b/gcc/brig/brigfrontend/brig-inst-mod-handler.cc
@@ -60,26 +60,26 @@ brig_inst_mod_handler::operator() (const BrigBase *base)
   return generate (base);
 
 #if 0
-	const BrigAluModifier *inst_modifier = modifier (base);
-	const bool FTZ = inst_modifier != NULL && inst_modifier->allBits & BRIG_ALU_FTZ;
+  const BrigAluModifier *inst_modifier = modifier (base);
+  const bool FTZ = inst_modifier != NULL
+    && inst_modifier->allBits & BRIG_ALU_FTZ;
   if (FTZ)
     {
-			static tree built_in = NULL_TREE;
-			tree call = call_builtin
-				(&built_in, "__phsa_builtin_enable_ftz", 0,
-				 void_type_node);
-			m_parent.append_statement (call);
-			DECL_IS_NOVOPS (built_in) = 1;
-			TREE_SIDE_EFFECTS (call) = 1;
+      static tree built_in = NULL_TREE;
+      tree call = call_builtin (&built_in, "__phsa_builtin_enable_ftz", 0,
+				void_type_node);
+      m_parent.append_statement (call);
+      DECL_IS_NOVOPS (built_in) = 1;
+      TREE_SIDE_EFFECTS (call) = 1;
     }
 
-	const BrigRound8_t *round_modifier = round (base);
+  const BrigRound8_t *round_modifier = round (base);
   // TODO: Set the default rounding mode once in the function entry (and
   // restore at function exit), and assume it's set by default so we don't
   // have to reset it for each instruction.
   BrigRound8_t brig_rounding_mode = m_parent.default_float_rounding_mode;
-	if (round_modifier != NULL)
-		brig_rounding_mode = *round_modifier;
+  if (round_modifier != NULL)
+    brig_rounding_mode = *round_modifier;
 
   tree new_mode = NULL_TREE;
   switch (brig_rounding_mode)
@@ -87,7 +87,7 @@ brig_inst_mod_handler::operator() (const BrigBase *base)
       // TODO: these are from fenv.h for x86-64/Linux, there should
       // be a target hook for querying the parameters or getting
       // the trees to change the modes directly.
-		case BRIG_ROUND_INTEGER_NEAR_EVEN:
+    case BRIG_ROUND_INTEGER_NEAR_EVEN:
     case BRIG_ROUND_FLOAT_NEAR_EVEN: // FE_TONEAREST
       new_mode = build_int_cst (integer_type_node, 0);
       break;
@@ -104,61 +104,62 @@ brig_inst_mod_handler::operator() (const BrigBase *base)
       new_mode = NULL_TREE;
       break;
     case BRIG_ROUND_FLOAT_DEFAULT:
-			break;
+      break;
     default:
       internal_error ("rounding mode %d unimplemented", brig_rounding_mode);
       break;
     }
 
-	tree old_mode = NULL_TREE;
-	if (new_mode != NULL_TREE)
-		{
-			// TODO: the target might have rounding
-			// modes per instruction, then the mode switching should
-			// not be used but the correct opcode should be called instead.
+    tree old_mode = NULL_TREE;
+    if (new_mode != NULL_TREE)
+      {
+	// TODO: the target might have rounding
+	// modes per instruction, then the mode switching should
+	// not be used but the correct opcode should be called instead.
 
-			// Emit a call to fegetround() to save the current
-			// rounding mode to a temporary variable.
-			// atomic_assign_expand_fenv() target hook
-			// is close to what is wanted here, but it is meant for
-			// disabling exceptions during an atomic operation.
+	// Emit a call to fegetround() to save the current
+	// rounding mode to a temporary variable.
+	// atomic_assign_expand_fenv () target hook
+	// is close to what is wanted here, but it is meant for
+	// disabling exceptions during an atomic operation.
 
-			tree save_call = build_call_expr (m_parent.fegetround_fn, 0);
-			tree ret_type = TREE_TYPE (TREE_TYPE (m_parent.fegetround_fn));
-			old_mode = create_tmp_var (ret_type, 0);
+	tree save_call = build_call_expr (m_parent.fegetround_fn, 0);
+	tree ret_type = TREE_TYPE (TREE_TYPE (m_parent.fegetround_fn));
+	old_mode = create_tmp_var (ret_type, 0);
 
-			tree assign_temp =
-				build2 (MODIFY_EXPR, TREE_TYPE (old_mode), old_mode, save_call);
-			m_parent.append_statement (assign_temp);
+	tree assign_temp
+	  = build2 (MODIFY_EXPR, TREE_TYPE (old_mode), old_mode, save_call);
+	m_parent.append_statement (assign_temp);
 
-			// Switch the rounding mode to what is requested by the HSAIL instruction.
-			tree set_call = build_call_expr (m_parent.fesetround_fn, 1, new_mode);
-			m_parent.append_statement (set_call);
-		}
+	/* Switch the rounding mode to what is requested
+	   by the HSAIL instruction.  */
+	tree set_call = build_call_expr (m_parent.fesetround_fn, 1, new_mode);
+	m_parent.append_statement (set_call);
+      }
 
-	// Delegate the generation of the actual instruction to
-	// the base instruction handler.
-	size_t count = generate (base);
+    // Delegate the generation of the actual instruction to
+    // the base instruction handler.
+    size_t count = generate (base);
 
-	if (new_mode != NULL_TREE)
-		{
-			// TODO: Emit a call to fesetround(int rounding_mode) to
-			// set the rounding mode to the one stated in the modifier.
-
-			tree restore_call = build_call_expr (m_parent.fesetround_fn, 1, old_mode);
-			m_parent.append_statement (restore_call);
-		}
-
-  if (FTZ)
+    if (new_mode != NULL_TREE)
     {
-			static tree built_in = NULL_TREE;
-			tree call = call_builtin
-				(&built_in, "__phsa_builtin_disable_ftz", 0,
-				 void_type_node);
-			m_parent.append_statement (call);
-			DECL_IS_NOVOPS (built_in) = 1;
-			TREE_SIDE_EFFECTS (call) = 1;
+      // TODO: Emit a call to fesetround (int rounding_mode) to
+      // set the rounding mode to the one stated in the modifier.
+
+      tree restore_call = build_call_expr (m_parent.fesetround_fn, 1,
+					   old_mode);
+      m_parent.append_statement (restore_call);
     }
+
+    if (FTZ)
+      {
+	static tree built_in = NULL_TREE;
+	tree call = call_builtin (&built_in, "__phsa_builtin_disable_ftz", 0,
+				  void_type_node);
+	m_parent.append_statement (call);
+	DECL_IS_NOVOPS (built_in) = 1;
+	TREE_SIDE_EFFECTS (call) = 1;
+      }
 
   // OPTIMIZE: Remove unneeded rounding mode switches, e.g. for successive
   // instructions with the same mode in the same BB.


### PR DESCRIPTION
Following patch fixes GNU coding style, where all lines should be limited to 80 characters.
Apart from that I fixed a bit formatting in brig-inst-mod-handler.cc.

Thanks,
Martin
