### PR TITLE
brig defaults to -O3, more optimizations disabled and tests added for -fftz-math

### DIFF
--- a/gcc/brig/brig-lang.c
+++ b/gcc/brig/brig-lang.c
@@ -133,6 +133,8 @@ brig_langhook_init_options_struct (struct gcc_options *opts)
      example, X * (+/-)1.0 -> (+/-)X simplification is not valid for
      subnormals. */
   opts->x_flag_ftz_math = 1;
+
+  opts->x_optimize = 3;
 }
 
 /* Handle Brig specific options.  Return 0 if we didn't do anything.  */

--- a/gcc/doc/invoke.texi
+++ b/gcc/doc/invoke.texi
@@ -9461,13 +9461,13 @@ disable all GCC optimizations that affect signaling NaN behavior.
 @item -fftz-math
 @opindex ftz-math
 This option is experimental. With this flag on GCC treats
-floating-point operations (except abs, class, copysign and neg) as
-they must flush subnormal input operands and results to zero
-(FTZ). The FTZ rules are derived from HSA Programmers Reference Manual
-for the base profile. This alters optimizations that would break the
-rules, for example X * 1 -> X simplification. The option assumes the
-target supports FTZ in hardware and has it enabled - either by default
-or set by the user.
+floating-point operations (except abs, classify, copysign and
+negation) as they must flush subnormal input operands and results to
+zero (FTZ). The FTZ rules are derived from HSA Programmers Reference
+Manual for the base profile. This alters optimizations that would
+break the rules, for example X * 1 -> X simplification. The option
+assumes the target supports FTZ in hardware and has it enabled -
+either by default or set by the user.
 
 @item -fno-fp-int-builtin-inexact
 @opindex fno-fp-int-builtin-inexact

--- a/gcc/fold-const-call.c
+++ b/gcc/fold-const-call.c
@@ -697,7 +697,7 @@ fold_const_call_ss (real_value *result, combined_fn fn,
 	      && do_mpfr_arg1 (result, mpfr_y1, arg, format));
 
     CASE_CFN_FLOOR:
-      if ((!REAL_VALUE_ISNAN (*arg) || !flag_errno_math) && !flag_ftz_math)
+      if (!REAL_VALUE_ISNAN (*arg) || !flag_errno_math)
 	{
 	  real_floor (result, format, arg);
 	  return true;
@@ -705,7 +705,7 @@ fold_const_call_ss (real_value *result, combined_fn fn,
       return false;
 
     CASE_CFN_CEIL:
-      if ((!REAL_VALUE_ISNAN (*arg) || !flag_errno_math) && !flag_ftz_math)
+      if (!REAL_VALUE_ISNAN (*arg) || !flag_errno_math)
 	{
 	  real_ceil (result, format, arg);
 	  return true;
@@ -1049,7 +1049,8 @@ fold_const_call_1 (combined_fn fn, tree type, tree arg)
   if (real_cst_p (arg))
     {
       gcc_checking_assert (SCALAR_FLOAT_MODE_P (arg_mode));
-      if (mode == arg_mode)
+      /* For -fftz-math subnormals are not folded correctly.  */
+      if (mode == arg_mode && !flag_ftz_math)
 	{
 	  /* real -> real.  */
 	  REAL_VALUE_TYPE result;
@@ -1299,7 +1300,8 @@ fold_const_call_1 (combined_fn fn, tree type, tree arg0, tree arg1)
       && real_cst_p (arg1))
     {
       gcc_checking_assert (SCALAR_FLOAT_MODE_P (arg0_mode));
-      if (mode == arg0_mode)
+      /* For -fftz-math subnormals are not folded correctly.  */
+      if (mode == arg0_mode && !flag_ftz_math)
 	{
 	  /* real, real -> real.  */
 	  REAL_VALUE_TYPE result;
@@ -1494,7 +1496,8 @@ fold_const_call_1 (combined_fn fn, tree type, tree arg0, tree arg1, tree arg2)
       && real_cst_p (arg2))
     {
       gcc_checking_assert (SCALAR_FLOAT_MODE_P (arg0_mode));
-      if (mode == arg0_mode)
+      /* For -fftz-math subnormals are not folded correctly.  */
+      if (mode == arg0_mode && !flag_ftz_math)
 	{
 	  /* real, real, real -> real.  */
 	  REAL_VALUE_TYPE result;

--- a/gcc/fold-const.c
+++ b/gcc/fold-const.c
@@ -1152,7 +1152,8 @@ const_binop (enum tree_code code, tree arg1, tree arg2)
       bool inexact;
       tree t, type;
 
-      /* For ftz-math disable all constant folding for now.  */
+      /* For ftz-math disable all floating point constant folding for
+	 now.  */
       if (flag_ftz_math)
 	return NULL_TREE;
 
@@ -6537,8 +6538,7 @@ fold_real_zero_addition_p (const_tree type, const_tree addend, int negate)
   if (!real_zerop (addend))
     return false;
 
-  /* For ftz-math subnormals must be flushed to zero. Disable folding
-     for now.  */
+  /* X +/- 0 flushes subnormals to zero but plain X does not.  */
   if (flag_ftz_math)
     return false;
 
@@ -9123,7 +9123,8 @@ fold_binary_loc (location_t loc,
   arg0 = op0;
   arg1 = op1;
 
-  /* For ftz-math disable all constant folding for now.  */
+  /* For ftz-math disable all floating point constant folding for
+     now.  */
   if (flag_ftz_math && FLOAT_TYPE_P (type))
     return NULL_TREE;
 

--- a/gcc/fold-const.c
+++ b/gcc/fold-const.c
@@ -1152,6 +1152,10 @@ const_binop (enum tree_code code, tree arg1, tree arg2)
       bool inexact;
       tree t, type;
 
+      /* For ftz-math disable all constant folding for now.  */
+      if (flag_ftz_math)
+	return NULL_TREE;
+
       /* The following codes are handled by real_arithmetic.  */
       switch (code)
 	{
@@ -1999,6 +2003,10 @@ fold_convert_const_real_from_real (tree type, const_tree arg1)
   if (HONOR_SNANS (TYPE_MODE (TREE_TYPE (arg1)))
       && REAL_VALUE_ISSIGNALING_NAN (TREE_REAL_CST (arg1)))
     return NULL_TREE; 
+
+  /* For ftz-math constant folding is disabled for now.  */
+  if (flag_ftz_math)
+    return NULL_TREE;
 
   real_convert (&value, TYPE_MODE (type), &TREE_REAL_CST (arg1));
   t = build_real (type, value);
@@ -6529,6 +6537,11 @@ fold_real_zero_addition_p (const_tree type, const_tree addend, int negate)
   if (!real_zerop (addend))
     return false;
 
+  /* For ftz-math subnormals must be flushed to zero. Disable folding
+     for now.  */
+  if (flag_ftz_math)
+    return false;
+
   /* Don't allow the fold with -fsignaling-nans.  */
   if (HONOR_SNANS (element_mode (type)))
     return false;
@@ -9109,6 +9122,10 @@ fold_binary_loc (location_t loc,
 
   arg0 = op0;
   arg1 = op1;
+
+  /* For ftz-math disable all constant folding for now.  */
+  if (flag_ftz_math && FLOAT_TYPE_P (type))
+    return NULL_TREE;
 
   /* Strip any conversions that don't change the mode.  This is
      safe for every expression, except for a comparison expression
@@ -13821,6 +13838,10 @@ fold_relational_const (enum tree_code code, tree type, tree op0, tree op1)
 
   if (TREE_CODE (op0) == REAL_CST && TREE_CODE (op1) == REAL_CST)
     {
+      /* For ftz-math disable all constant folding for now.  */
+      if (flag_ftz_math)
+	return NULL_TREE;
+
       const REAL_VALUE_TYPE *c0 = TREE_REAL_CST_PTR (op0);
       const REAL_VALUE_TYPE *c1 = TREE_REAL_CST_PTR (op1);
 

--- a/gcc/match.pd
+++ b/gcc/match.pd
@@ -1644,7 +1644,8 @@ DEFINE_INT_AND_FLOAT_ROUND_FN (RINT)
 (for minmax (min max FMIN FMAX)
  (simplify
   (minmax @0 @0)
-  @0))
+   (if (FLOAT_TYPE_P (type) && !flag_ftz_math)
+    @0)))
 /* min(max(x,y),y) -> y.  */
 (simplify
  (min:c (max:c @0 @1) @1)
@@ -2106,7 +2107,7 @@ DEFINE_INT_AND_FLOAT_ROUND_FN (RINT)
 	  || (GENERIC
 	      && TYPE_MAIN_VARIANT (type) == TYPE_MAIN_VARIANT (inside_type)))
 	 && (((inter_int || inter_ptr) && final_int)
-	     || (inter_float && final_float))
+	     || (inter_float && final_float && !flag_ftz_math))
 	 && inter_prec >= final_prec)
      (ocvt @0))
 
@@ -2115,7 +2116,8 @@ DEFINE_INT_AND_FLOAT_ROUND_FN (RINT)
        former is wider than the latter and doesn't change the signedness
        (for integers).  Avoid this if the final type is a pointer since
        then we sometimes need the middle conversion.  */
-    (if (((inter_int && inside_int) || (inter_float && inside_float))
+    (if (((inter_int && inside_int) || (inter_float && inside_float
+					&& !flag_ftz_math))
 	 && (final_int || final_float)
 	 && inter_prec >= inside_prec
 	 && (inter_float || inter_unsignedp == inside_unsignedp))

--- a/gcc/simplify-rtx.c
+++ b/gcc/simplify-rtx.c
@@ -1249,8 +1249,9 @@ simplify_unary_operation_1 (enum rtx_code code, machine_mode mode, rtx op)
       if (DECIMAL_FLOAT_MODE_P (mode))
 	break;
 
-      /* (float_truncate:SF (float_extend:DF foo:SF)) = foo:SF.  */
-      if (GET_CODE (op) == FLOAT_EXTEND
+      /* (float_truncate:SF (float_extend:DF foo:SF)) = foo:SF except
+	 for -fftz-math with subnormal input.  */
+      if (!flag_ftz_math && GET_CODE (op) == FLOAT_EXTEND
 	  && GET_MODE (XEXP (op, 0)) == mode)
 	return XEXP (op, 0);
 
@@ -1899,15 +1900,19 @@ simplify_const_unary_operation (enum rtx_code code, machine_mode mode,
 	  break;
 	case FLOAT_TRUNCATE:
 	  /* Don't perform the operation if flag_signaling_nans is on
-	     and the operand is a signaling NaN.  */
-	  if (HONOR_SNANS (mode) && REAL_VALUE_ISSIGNALING_NAN (d))
+	     and the operand is a signaling NaN. For -fftz-math
+	     denormal input and output value must be flushed.  */
+	  if ((HONOR_SNANS (mode) && REAL_VALUE_ISSIGNALING_NAN (d))
+	      || flag_ftz_math)
 	    return NULL_RTX;
 	  d = real_value_truncate (mode, d);
 	  break;
 	case FLOAT_EXTEND:
 	  /* Don't perform the operation if flag_signaling_nans is on
-	     and the operand is a signaling NaN.  */
-	  if (HONOR_SNANS (mode) && REAL_VALUE_ISSIGNALING_NAN (d))
+	     and the operand is a signaling NaN. For -fftz-math
+	     denormal input and outputs must be flushed.  */
+	  if ((HONOR_SNANS (mode) && REAL_VALUE_ISSIGNALING_NAN (d))
+	       || flag_ftz_math)
 	    return NULL_RTX;
 	  /* All this does is change the mode, unless changing
 	     mode class.  */
@@ -2142,11 +2147,13 @@ simplify_binary_operation_1 (enum rtx_code code, machine_mode mode,
   switch (code)
     {
     case PLUS:
-      /* Maybe simplify x + 0 to x.  The two expressions are equivalent
-	 when x is NaN, infinite, or finite and nonzero.  They aren't
-	 when x is -0 and the rounding mode is not towards -infinity,
-	 since (-0) + 0 is then 0.  */
-      if (!HONOR_SIGNED_ZEROS (mode) && trueop1 == CONST0_RTX (mode))
+      /* Maybe simplify x + 0 to x.  The two expressions are
+	 equivalent when x is NaN, infinite, or finite and nonzero.
+	 They aren't when x is -0 and the rounding mode is not towards
+	 -infinity, since (-0) + 0 is then 0. For -ftz-math x must be
+	 flushed to zero in case of subnormal.  */
+      if (!HONOR_SIGNED_ZEROS (mode) && !flag_ftz_math
+	  && trueop1 == CONST0_RTX (mode))
 	return op0;
 
       /* ((-a) + b) -> (b - a) and similarly for (a + (-b)).  These
@@ -2349,10 +2356,12 @@ simplify_binary_operation_1 (enum rtx_code code, machine_mode mode,
 	return simplify_gen_unary (NOT, mode, op1, mode);
 
       /* Subtracting 0 has no effect unless the mode has signed zeros
-	 and supports rounding towards -infinity.  In such a case,
-	 0 - 0 is -0.  */
-      if (!(HONOR_SIGNED_ZEROS (mode)
-	    && HONOR_SIGN_DEPENDENT_ROUNDING (mode))
+	 and supports rounding towards -infinity.  In such a case, 0 -
+	 0 is -0. For -ftz-math x must be flushed to zero in case of
+	 subnormal.  */
+      if (!((HONOR_SIGNED_ZEROS (mode)
+	     && HONOR_SIGN_DEPENDENT_ROUNDING (mode))
+	    || flag_ftz_math)
 	  && trueop1 == CONST0_RTX (mode))
 	return op0;
 
@@ -4013,6 +4022,10 @@ simplify_const_binary_operation (enum rtx_code code, machine_mode mode,
 	  const REAL_VALUE_TYPE *opr0, *opr1;
 	  bool inexact;
 
+	  /* Subnormals are not handled corretly with -fftz-math.  */
+	  if (flag_ftz_math)
+	    return 0;
+
 	  opr0 = CONST_DOUBLE_REAL_VALUE (op0);
 	  opr1 = CONST_DOUBLE_REAL_VALUE (op1);
 
@@ -5094,8 +5107,10 @@ simplify_const_relational_operation (enum rtx_code code,
     return comparison_result (code, CMP_EQ);
 
   /* If the operands are floating-point constants, see if we can fold
-     the result.  */
-  if (CONST_DOUBLE_AS_FLOAT_P (trueop0)
+     the result. For -fftz-math disable simplification as subnormals
+     are not handled correcty.  */
+  if (!flag_ftz_math
+      && CONST_DOUBLE_AS_FLOAT_P (trueop0)
       && CONST_DOUBLE_AS_FLOAT_P (trueop1)
       && SCALAR_FLOAT_MODE_P (GET_MODE (trueop0)))
     {

--- a/gcc/testsuite/gcc.dg/ftz-math.c
+++ b/gcc/testsuite/gcc.dg/ftz-math.c
@@ -1,8 +1,13 @@
 /* Tests -fftz-math flag */
 /* { dg-do run { target x86_64-*-* } } */
-/* { dg-options "-O2 -fftz-math" } */
+/* { dg-options "-O2 -Wall -Wpedantic -fftz-math" } */
 
 #include <math.h>
+
+/* #define DEBUG_TEST */
+#ifdef DEBUG_TEST
+#  include <stdio.h>
+#endif
 
 #include "xmmintrin.h"
 #include "pmmintrin.h"
@@ -13,6 +18,12 @@ union uf
   float f;
 };
 
+union ud
+{
+  unsigned long long u;
+  double d;
+};
+
 static unsigned int
 f2u (float v)
 {
@@ -21,6 +32,15 @@ f2u (float v)
   return u.u;
 }
 
+static unsigned long long
+d2u (double v)
+{
+  union ud u;
+  u.d = v;
+  return u.u;
+}
+
+
 static void
 enable_ftz_mode ()
 {
@@ -28,24 +48,61 @@ enable_ftz_mode ()
   _MM_SET_DENORMALS_ZERO_MODE (_MM_DENORMALS_ZERO_ON);
 }
 
-static void
-test_is_zero (float x)
+static int
+test_sf_is_zero (float x)
 {
   /* FTZ mode is on, must do bitwise ops for zero test. */
-  if ((f2u (x) & 0x7fffffff) != 0u)
-    abort ();
+  return ((f2u (x) & 0x7fffffffu) == 0u);
 }
 
-static void
-test_is_subnormal (float x) {
+static int
+test_df_is_zero (double x)
+{
+  /* FTZ mode is on, must do bitwise ops for zero test. */
+  return ((d2u (x) & 0x7fffffffffffffffull) == 0ull);
+}
+
+static int
+test_sf_is_subnormal (float x) {
   unsigned int u = f2u (x);
-  if (u & 0x7f800000)
-    abort ();
-  if (!(u & 0x007fffff))
-    abort ();
+  if (u & 0x7f800000u)
+    return 0;
+  return (u & 0x007fffffu);
 }
 
-volatile float gf;
+static int
+test_df_is_subnormal (double x) {
+  unsigned long long u = d2u (x);
+  if (u & 0x7ff0000000000000ull)
+    return 0;
+  return (u & 0x000fffffffffffffull);
+}
+
+#ifdef DEBUG_TEST
+void err_print (unsigned line, const char* expr)
+{
+  printf ("Line %d: FAIL: %s\n", line, expr);
+  abort ();
+}
+#  define TEST_SF_IS_ZERO(expr) \
+  if (!test_sf_is_zero (expr)) err_print (__LINE__, #expr)
+#  define TEST_SF_IS_SUBNORMAL(expr) \
+  if (!test_sf_is_subnormal (expr)) err_print (__LINE__, #expr)
+#  define TEST_DF_IS_ZERO(expr) \
+  if (!test_df_is_zero (expr)) err_print (__LINE__, #expr)
+#  define TEST_DF_IS_SUBNORMAL(expr) \
+  if (!test_df_is_subnormal (expr)) err_print (__LINE__, #expr)
+#  define TEST_TRUE(expr) if (!(expr)) err_print (__LINE__, #expr)
+#else
+#  define TEST_SF_IS_ZERO(expr) if (!test_sf_is_zero (expr)) abort ()
+#  define TEST_SF_IS_SUBNORMAL(expr) if (!test_sf_is_subnormal (expr)) abort ()
+#  define TEST_DF_IS_ZERO(expr) if (!test_df_is_zero (expr)) abort ()
+#  define TEST_DF_IS_SUBNORMAL(expr) if (!test_df_is_subnormal (expr)) abort ()
+#  define TEST_TRUE(expr) if (!(expr)) abort ()
+#endif
+
+volatile float sf;
+volatile double df;
 
 int
 main ()
@@ -53,35 +110,221 @@ main ()
   enable_ftz_mode ();
 
   /* Circulate through volatile to avoid constant folding. */
-  gf = 2.87E-42; /* = subnormal */
-  float x = gf;
+  sf = 2.87E-42f; /* = subnormal */
+  float x = sf;
 
-  test_is_subnormal (x); /* Store/load should not flush. */
+  TEST_SF_IS_SUBNORMAL (x); /* Store/load should not flush. */
+  TEST_TRUE (!isnormal (x));
+  TEST_TRUE (fpclassify (x) == FP_SUBNORMAL);
+
+  TEST_DF_IS_ZERO ((double) x);
 
   /* Test the expression is not simplified to plain x, thus, leaking the
      subnormal. */
-  test_is_zero (x*1);
-  test_is_zero (x*-1);
-  test_is_zero (x*0.5);
+  TEST_SF_IS_ZERO (x * 1);
+  TEST_SF_IS_ZERO (x * -1);
+  TEST_SF_IS_ZERO (x * 0.5);
 
-  test_is_zero (x/1);
-  test_is_zero (x/-1);
-  test_is_zero (x/2);
+  TEST_SF_IS_ZERO (x / 1);
+  TEST_SF_IS_ZERO (x / -1);
+  TEST_SF_IS_ZERO (x / 2);
+
+  TEST_SF_IS_ZERO (fminf (x, x));
+  TEST_SF_IS_ZERO (fminf (x, -x));
+  TEST_SF_IS_ZERO (fmaxf (x, x));
+  TEST_SF_IS_ZERO (fmaxf (x, -x));
+
+  TEST_SF_IS_ZERO (x + 0);
+  TEST_SF_IS_ZERO (0 - x);
+
+  TEST_SF_IS_ZERO (x - 0);
+  TEST_SF_IS_ZERO (x + x);
+
+  TEST_SF_IS_ZERO (x + 0.0f);
+  TEST_SF_IS_ZERO (0.0f - x);
+  TEST_SF_IS_ZERO (x - 0.0f);
+  TEST_SF_IS_ZERO (x + x);
+
+  TEST_SF_IS_ZERO (x * copysignf (1.0f, x));
+  TEST_SF_IS_ZERO (x * copysignf (1.0f, -x));
+
+  float y = sf;
+  TEST_SF_IS_ZERO (fminf (fmaxf (x, y), y));
+
+  TEST_SF_IS_SUBNORMAL (x == y ? x : y);
+  TEST_SF_IS_SUBNORMAL (x != y ? x : y);
+  TEST_SF_IS_SUBNORMAL (x >= y ? x : y);
+  TEST_SF_IS_SUBNORMAL (x > y ? x : y);
+  TEST_SF_IS_SUBNORMAL (x <= y ? x : y);
+  TEST_SF_IS_SUBNORMAL (x < y ? x : y);
 
   /* FP ops that should not flush. */
-  test_is_subnormal (fabsf (x));
-  test_is_subnormal (x < 0 ? -x : x);
-  test_is_subnormal (-x);
-  test_is_subnormal (copysignf (x, -1.0));
+  TEST_SF_IS_SUBNORMAL (fabsf (x));
+  TEST_SF_IS_SUBNORMAL (x < 0 ? -x : x);
+  TEST_SF_IS_SUBNORMAL (-x);
+  TEST_SF_IS_SUBNORMAL (copysignf (x, -1.0));
 
-  /* Test constant folding. */
+  /* Test constant folding with subnormal values. */
+  TEST_TRUE (!isnormal (2.87E-42f));
 
-  test_is_subnormal (fabsf (-2.87E-42));
-  test_is_subnormal (copysignf (2.87E-42, -1.0));
+  TEST_SF_IS_SUBNORMAL (-(2.87E-42f));
+  TEST_SF_IS_SUBNORMAL (fabsf (-2.87E-42f));
+  TEST_SF_IS_SUBNORMAL (copysignf (2.87E-42f, -1.0));
 
-  /* floor and ceil must see flushed value. */
-  test_is_zero (floorf (-2.87E-42));
-  test_is_zero (ceilf (2.87E-42));
+  TEST_SF_IS_ZERO (fminf (2.87E-42f, 2.87E-42f));
+  TEST_SF_IS_ZERO (fminf (2.87E-42f, -5.74E-42f));
+  TEST_SF_IS_ZERO (fmaxf (2.87E-42f, 2.87E-42f));
+  TEST_SF_IS_ZERO (fmaxf (2.87E-42f, -5.74E-42f));
+
+  TEST_SF_IS_ZERO (floorf (-2.87E-42f));
+  TEST_SF_IS_ZERO (ceilf (2.87E-42f));
+
+  TEST_SF_IS_ZERO (sqrtf (2.82E-42f));
+
+  TEST_SF_IS_ZERO (2.87E-42f + 0.0f);
+  TEST_SF_IS_ZERO (2.87E-42f + 5.74E-42f);
+  TEST_SF_IS_ZERO (2.87E-42f - 0.0f);
+  TEST_SF_IS_ZERO (0.0f - 2.87E-42f);
+  TEST_SF_IS_ZERO (2.87E-42f * 1.0f);
+  TEST_SF_IS_ZERO (2.87E-42f * -1.0f);
+  TEST_SF_IS_ZERO (2.87E-42f * 12.3f);
+  TEST_SF_IS_ZERO (2.87E-42f / 1.0f);
+  TEST_SF_IS_ZERO (2.87E-42f / 12.3f);
+
+  TEST_TRUE (2.87E-42f == -5.74E-42f);
+  TEST_TRUE (2.87E-42f == -5.74E-42f ? 1 : 0);
+
+  TEST_TRUE (2.87E-42f == -5.74E-42f ? 1 : 0);
+  TEST_TRUE (2.87E-42f != -5.74E-42f ? 0 : 1);
+  TEST_TRUE (2.87E-42f >= -5.74E-42f ? 1 : 0);
+  TEST_TRUE (2.87E-42f >= 5.74E-42f ? 1 : 0);
+  TEST_TRUE (2.87E-42f > -5.74E-42f ? 0 : 1);
+  TEST_TRUE (2.87E-42f > 5.74E-42f ? 0 : 1);
+  TEST_TRUE (2.87E-42f <= -5.74E-42f ? 1 : 0);
+  TEST_TRUE (2.87E-42f <= 5.74E-42f ? 1 : 0);
+  TEST_TRUE (2.87E-42f < -5.74E-42f ? 0 : 1);
+  TEST_TRUE (2.87E-42f < 5.74E-42f ? 0 : 1);
+
+  /*  A < B ? A : B -> min (B, A)  must not happen (min flushes to zero).*/
+  TEST_SF_IS_SUBNORMAL (2.87E-42f < -5.74E-42f ? 2.87E-42f : -5.74E-42f);
+
+  /* Normal and subnormal input. */
+  TEST_TRUE ((2.87E-42f + 1.1754944E-38f) == 1.1754944E-38f);
+  TEST_TRUE ((1.1754944E-38f - 2.87E-42f) == 1.1754944E-38f);
+
+  /* Expression with normal numbers. Result of the Substraction is
+     subnormal. */
+  float sf_tmp = (1.469368E-38f - 1.1754944E-38f) + 1.1754944E-38f;
+  TEST_TRUE (sf_tmp == 1.1754944E-38f);
+
+
+  /*** Test with double precision. ***/
+  df = 5.06E-321;
+  double dx = df;
+
+  TEST_DF_IS_SUBNORMAL (dx);
+  TEST_TRUE (!isnormal (dx));
+  TEST_TRUE (fpclassify (dx) == FP_SUBNORMAL);
+
+  TEST_SF_IS_ZERO ((float)dx);
+
+  TEST_DF_IS_ZERO (dx * 1);
+  TEST_DF_IS_ZERO (dx * -1);
+  TEST_DF_IS_ZERO (dx * 0.5);
+
+  TEST_DF_IS_ZERO (dx / 1);
+  TEST_DF_IS_ZERO (dx / -1);
+  TEST_DF_IS_ZERO (dx / 2);
+
+  TEST_DF_IS_ZERO (fmin (dx, dx));
+  TEST_DF_IS_ZERO (fmin (dx, -dx));
+  TEST_DF_IS_ZERO (fmax (dx, dx));
+  TEST_DF_IS_ZERO (fmax (dx, -dx));
+
+  TEST_DF_IS_ZERO (dx + 0);
+  TEST_DF_IS_ZERO (0 - dx);
+  TEST_DF_IS_ZERO (dx - 0);
+  TEST_DF_IS_ZERO (dx + dx);
+
+  TEST_DF_IS_ZERO (dx + 0.0);
+  TEST_DF_IS_ZERO (0.0 - dx);
+  TEST_DF_IS_ZERO (dx - 0.0);
+
+  TEST_DF_IS_ZERO (dx * copysign (1.0, dx));
+  TEST_DF_IS_ZERO (dx * copysign (1.0, -dx));
+
+  df = -1.61895E-319;
+  double dy = df;
+  TEST_SF_IS_ZERO (fmin (fmax (dx, dy), dy));
+
+  TEST_DF_IS_SUBNORMAL (dx == dy ? dx : dy);
+  TEST_DF_IS_SUBNORMAL (dx != dy ? dx : dy);
+  TEST_DF_IS_SUBNORMAL (dx >= dy ? dx : dy);
+  TEST_DF_IS_SUBNORMAL (dx > dy ? dx : dy);
+  TEST_DF_IS_SUBNORMAL (dx <= dy ? dx : dy);
+  TEST_DF_IS_SUBNORMAL (dx < dy ? dx : dy);
+
+  /* FP ops that should not flush. */
+  TEST_DF_IS_SUBNORMAL (fabs (dx));
+  TEST_DF_IS_SUBNORMAL (dx < 0 ? -dx : dx);
+  TEST_DF_IS_SUBNORMAL (-dx);
+  TEST_DF_IS_SUBNORMAL (copysign (dx, -1.0));
+
+  /* Test constant folding with subnormal values. */
+
+  TEST_TRUE (!isnormal (5.06E-321));
+  TEST_TRUE (fpclassify (5.06E-321) == FP_SUBNORMAL);
+
+  TEST_DF_IS_SUBNORMAL (-(5.06E-321));
+  TEST_DF_IS_SUBNORMAL (fabs (-5.06E-321));
+  TEST_DF_IS_SUBNORMAL (copysign (5.06E-321, -1.0));
+
+  TEST_DF_IS_ZERO (fmin (5.06E-321, 5.06E-321));
+  TEST_DF_IS_ZERO (fmin (5.06E-321, -1.61895E-319));
+  TEST_DF_IS_ZERO (fmax (5.06E-321, 5.06E-321));
+  TEST_DF_IS_ZERO (fmax (5.06E-321, -1.61895E-319));
+
+  TEST_DF_IS_ZERO (floor (-5.06E-321));
+  TEST_DF_IS_ZERO (ceil (5.06E-321));
+  TEST_DF_IS_ZERO (sqrt (2.82E-42f));
+
+  TEST_DF_IS_ZERO (5.06E-321 + 0.0);
+  TEST_DF_IS_ZERO (5.06E-321 + 1.61895E-319);
+  TEST_DF_IS_ZERO (5.06E-321 - 0.0);
+  TEST_DF_IS_ZERO (0.0 - 5.06E-321);
+  TEST_DF_IS_ZERO (5.06E-321 * 1.0);
+  TEST_DF_IS_ZERO (5.06E-321 * -1.0);
+  TEST_DF_IS_ZERO (5.06E-321 * 12.3);
+  TEST_DF_IS_ZERO (5.06E-321 / 1.0);
+  TEST_DF_IS_ZERO (5.06E-321 / 12.3);
+
+  TEST_TRUE (5.06E-321 == -1.61895E-319);
+
+  TEST_TRUE (5.06E-321 == -1.61895E-319 ? 1 : 0);
+  TEST_TRUE (5.06E-321 == -1.61895E-319 ? 1 : 0);
+  TEST_TRUE (5.06E-321 != -1.61895E-319 ? 0 : 1);
+  TEST_TRUE (5.06E-321 >= -1.61895E-319 ? 1 : 0);
+  TEST_TRUE (5.06E-321 >= 1.61895E-319 ? 1 : 0);
+  TEST_TRUE (5.06E-321 > -1.61895E-319 ? 0 : 1);
+  TEST_TRUE (5.06E-321 > 1.61895E-319 ? 0 : 1);
+  TEST_TRUE (5.06E-321 <= -1.61895E-319 ? 1 : 0);
+  TEST_TRUE (5.06E-321 <= 1.61895E-319 ? 1 : 0);
+  TEST_TRUE (5.06E-321 < -1.61895E-319 ? 0 : 1);
+  TEST_TRUE (5.06E-321 < 1.61895E-319 ? 0 : 1);
+
+  /*  A < B ? A : B -> min (B, A)  must not happen (min flushes to zero).*/
+  TEST_DF_IS_SUBNORMAL (5.06E-321 < -1.61895E-319 ? 5.06E-321 : -1.61895E-319);
+
+  /* Normal and subnormal input. */
+  TEST_TRUE ((5.06E-321 + 3.33E-308) == 3.33E-308);
+  TEST_TRUE ((3.33E-308 - 5.06E-321) == 3.33E-308);
+
+  /* Expression with normal numbers. Result of the Substraction is
+     subnormal. */
+  double df_a = 3.33E-308;
+  double df_b = 2.78E-308;
+  double df_tmp = (df_a - df_b) + df_b;
+  TEST_TRUE (df_tmp == df_b);
 
   return 0;
 }

--- a/gcc/testsuite/gcc.dg/ftz-math.c
+++ b/gcc/testsuite/gcc.dg/ftz-math.c
@@ -1,6 +1,6 @@
 /* Tests -fftz-math flag */
 /* { dg-do run { target x86_64-*-* } } */
-/* { dg-options "-O2 -Wall -Wpedantic -fftz-math" } */
+/* { dg-options "-O2 -fftz-math" } */
 
 #include <math.h>
 


### PR DESCRIPTION
* -O3 is default for brig
* Disabled more optimizations that break FTZ semantics. Most of them are doing constant folding.
* Added more tests for -fftz-math.
* Tweaked -fftz-math documentation