### PR TITLE
Fix brig1 crash. Fix only one work-item is executed

### DIFF
--- a/gcc/brig/ChangeLog
+++ b/gcc/brig/ChangeLog
@@ -1,3 +1,8 @@
+2017-10-02  Henry Linjamäki  <henry.linjamaki@parmance.com>
+
+	* brig-branch-inst-handler.cc: Fix brig1 crashed on HSAIL function
+	calls having 5+ args. Fix only one work-item is executed.
+
 2017-08-31  Henry Linjamäki  <henry.linjamaki@parmance.com>
 
 	* brig-lang.c: Added function attributes and their handlers.

--- a/gcc/brig/brigfrontend/brig-branch-inst-handler.cc
+++ b/gcc/brig/brigfrontend/brig-branch-inst-handler.cc
@@ -69,7 +69,7 @@ brig_branch_inst_handler::operator () (const BrigBase *base)
 	  const BrigOperandOffset32_t *operand_ptr
 	    = (const BrigOperandOffset32_t *) data->bytes;
 
-	  vec<tree, va_gc> *args = i == 0 ? out_args : in_args;
+	  vec<tree, va_gc> *&args = i == 0 ? out_args : in_args;
 
 	  while (bytes > 0)
 	    {
@@ -147,7 +147,6 @@ brig_branch_inst_handler::operator () (const BrigBase *base)
 	  m_parent.m_cf->append_statement (call);
 	}
 
-      m_parent.m_cf->m_has_unexpanded_dp_builtins = false;
       m_parent.m_cf->m_called_functions.push_back (func_ref);
 
       return base->byteCount;


### PR DESCRIPTION
* Fix brig code with +5 arguments crashes brig1.
* Fix only only work-item is executed